### PR TITLE
Replace browser alerts with Sonner toasts

### DIFF
--- a/async-code-web/app/page.tsx
+++ b/async-code-web/app/page.tsx
@@ -22,6 +22,7 @@ import { SupabaseService } from "@/lib/supabase-service";
 import { Project, Task } from "@/types";
 import { ClaudeIcon } from "@/components/icon/claude";
 import { OpenAIIcon } from "@/components/icon/openai";
+import { toast } from "sonner";
 
 interface TaskWithProject extends Task {
     project?: Project
@@ -135,12 +136,12 @@ export default function Home() {
 
     const handleStartTask = async () => {
         if (!prompt.trim() || !githubToken.trim()) {
-            alert('Please provide both a prompt and GitHub token');
+            toast.error('Please provide both a prompt and GitHub token');
             return;
         }
 
         if (!user?.id) {
-            alert('User not authenticated');
+            toast.error('User not authenticated');
             return;
         }
 
@@ -155,7 +156,7 @@ export default function Home() {
             }
         } else {
             // Custom repo URL - would need an input field for this
-            alert('Custom repo URL input not implemented yet. Please select a project or create one first.');
+            toast.error('Custom repo URL input not implemented yet. Please select a project or create one first.');
             return;
         }
 
@@ -196,7 +197,7 @@ export default function Home() {
             setShowNotification(true);
             setTimeout(() => setShowNotification(false), 5000);
         } catch (error) {
-            alert(`Error starting task: ${error}`);
+            toast.error(`Error starting task: ${error}`);
         } finally {
             setIsLoading(false);
         }

--- a/async-code-web/app/projects/page.tsx
+++ b/async-code-web/app/projects/page.tsx
@@ -13,6 +13,7 @@ import { ProtectedRoute } from "@/components/protected-route";
 import { useAuth } from "@/contexts/auth-context";
 import { ApiService } from "@/lib/api-service";
 import { Project } from "@/types";
+import { toast } from "sonner";
 
 interface ProjectWithStats extends Project {
     task_count?: number
@@ -68,7 +69,7 @@ export default function ProjectsPage() {
             loadProjects();
         } catch (error) {
             console.error('Error creating project:', error);
-            alert('Error creating project. Please check the GitHub URL format.');
+            toast.error('Error creating project. Please check the GitHub URL format.');
         }
     };
 
@@ -84,7 +85,7 @@ export default function ProjectsPage() {
             loadProjects();
         } catch (error) {
             console.error('Error deleting project:', error);
-            alert('Error deleting project');
+            toast.error('Error deleting project');
         }
     };
 

--- a/async-code-web/app/settings/page.tsx
+++ b/async-code-web/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
 
 import Link from "next/link";
 
@@ -42,7 +43,7 @@ export default function SettingsPage() {
 
     const handleValidateToken = async () => {
         if (!githubToken.trim() || !repoUrl.trim()) {
-            alert('Please provide both GitHub token and repository URL');
+            toast.error('Please provide both GitHub token and repository URL');
             return;
         }
 
@@ -74,15 +75,15 @@ export default function SettingsPage() {
                 ].join('\n');
                 
                 if (permissions.create_branches) {
-                    alert(`✅ Token is fully valid for PR creation!\n\n${permissionSummary}`);
+                    toast.success(`✅ Token is fully valid for PR creation!\n\n${permissionSummary}`);
                 } else {
-                    alert(`⚠️ Token validation partial success!\n\n${permissionSummary}\n\n❌ Cannot create branches - this will prevent PR creation.\nPlease ensure your token has &apos;repo&apos; scope (not just &apos;public_repo&apos;).`);
+                    toast.warning(`⚠️ Token validation partial success!\n\n${permissionSummary}\n\n❌ Cannot create branches - this will prevent PR creation.\nPlease ensure your token has 'repo' scope (not just 'public_repo').`);
                 }
             } else {
-                alert(`❌ Token validation failed: ${data.error}`);
+                toast.error(`❌ Token validation failed: ${data.error}`);
             }
         } catch (error) {
-            alert(`Error validating token: ${error}`);
+            toast.error(`Error validating token: ${error}`);
             setTokenValidation({ status: 'error', error: String(error) });
         } finally {
             setIsValidatingToken(false);


### PR DESCRIPTION
## Summary
- use shadcn Sonner toast notifications instead of browser alerts
- improve project management, home page, and settings UX

## Testing
- `./test-model-selection.sh` *(fails: couldn't connect to server)*
- `./test-api.sh`
- `npm test` in `async-code-web` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847163a52a483228f8e631bf34274f9