### PR TITLE
fix: add file command to claude automation container

### DIFF
--- a/Dockerfile.claude-automation
+++ b/Dockerfile.claude-automation
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
     curl \
     openssh-client \
     python3 \
-    py3-pip
+    py3-pip \
+    file
 
 # Install Claude Code globally
 RUN npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
Resolves missing 'file' command error in the Claude automation container by adding the file package to Alpine apk dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)