### PR TITLE
fix: properly escape credentials variable in bash script

### DIFF
--- a/server/utils/code_task_v2.py
+++ b/server/utils/code_task_v2.py
@@ -269,7 +269,7 @@ if [ "{model_cli}" = "claude" ]; then
     mkdir -p ~/.claude
     
     # Write credentials content directly to file
-    if [ ! -z '{escaped_credentials}' ]; then
+    if [ ! -z "{escaped_credentials}" ]; then
         echo "📋 Writing credentials to ~/.claude/.credentials.json"
         cat << 'CREDENTIALS_EOF' > ~/.claude/.credentials.json
 {credentials_content}


### PR DESCRIPTION
The escaped_credentials variable was using single quotes which prevented proper shell expansion. Changed to double quotes to allow variable substitution while maintaining safety.

🤖 Generated with [Claude Code](https://claude.ai/code)