### PR TITLE
fix: add Supabase environment variables to frontend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=development
+      - NEXT_PUBLIC_SUPABASE_URL=${SUPABASE_URL}
+      - NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+    env_file:
+      - ./server/.env
     volumes:
       - ./async-code-web:/app
       - /app/node_modules


### PR DESCRIPTION
The Next.js frontend requires NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables to initialize the Supabase client. These variables are now passed from the server/.env file to the frontend container.

This fixes the "Error: supabaseUrl is required" runtime error.